### PR TITLE
feat: post 공유 취소

### DIFF
--- a/src/main/java/com/example/cap1/domain/post/api/PostController.java
+++ b/src/main/java/com/example/cap1/domain/post/api/PostController.java
@@ -4,10 +4,7 @@ import com.example.cap1.domain.post.dto.response.PostShareResponseDto;
 import com.example.cap1.domain.post.service.PostService;
 import com.example.cap1.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,6 +16,12 @@ public class PostController {
     @PostMapping("/{postId}")
     public ResponseDto<PostShareResponseDto> postShare(@PathVariable Long postId) {
         PostShareResponseDto response = postService.updatePostShare(postId);
+        return ResponseDto.of(response);
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseDto<PostShareResponseDto> postUnshare(@PathVariable Long postId) {
+        PostShareResponseDto response = postService.updatePostUnShare(postId);
         return ResponseDto.of(response);
     }
 }

--- a/src/main/java/com/example/cap1/domain/post/domain/Post.java
+++ b/src/main/java/com/example/cap1/domain/post/domain/Post.java
@@ -42,4 +42,8 @@ public class Post extends BaseEntity {
     public void updateShare(){
         this.share = 1;
     }
+
+    public void updateUnShare(){
+        this.share = 0;
+    }
 }

--- a/src/main/java/com/example/cap1/domain/post/service/PostService.java
+++ b/src/main/java/com/example/cap1/domain/post/service/PostService.java
@@ -23,4 +23,14 @@ public class PostService {
         }
         return PostConverter.toPostShareResponseDto(post);
     }
+
+    public PostShareResponseDto updatePostUnShare(Long postId) {
+        Post post = postRepository.findById(postId).orElse(null);
+        if (post == null) {
+            return null;
+        } else{
+            post.updateUnShare();
+        }
+        return PostConverter.toPostShareResponseDto(post);
+    }
 }


### PR DESCRIPTION
## 📌 연관 이슈
- #12 

## 💻 작업 내용
악보 공유(post)를 취소하는 기능
악보를 비공개로 전환합니다.

### 📸 스크린샷 (선택)


### 💬리뷰 요구사항(선택)

