### PR TITLE
feat: 악보 생성 요청 api 구현

### DIFF
--- a/src/main/java/com/example/cap1/domain/transcription/client/AiServerClient.java
+++ b/src/main/java/com/example/cap1/domain/transcription/client/AiServerClient.java
@@ -1,6 +1,8 @@
 package com.example.cap1.domain.transcription.client;
 
 import com.example.cap1.domain.transcription.dto.ai.AiEnqueueResponse;
+import com.example.cap1.domain.transcription.dto.ai.AiResultResponse;
+import com.example.cap1.domain.transcription.dto.ai.AiStatusResponse;
 import com.example.cap1.global.exception.GeneralException;
 import com.example.cap1.global.response.Code;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class AiServerClient {
     @Value("${file.upload-dir}")
     private String uploadDir;
 
-    @Value("${ai.server.mock-mode:true}")  // 🆕 기본값 true (Mock 모드)
+    @Value("${ai.server.mock-mode:true}")
     private boolean mockMode;
 
     private final RestTemplate restTemplate;
@@ -38,33 +40,80 @@ public class AiServerClient {
      * E2E Task 등록 (음원 분리 + MIDI 변환 + 코드 인지)
      */
     public AiEnqueueResponse enqueueE2ETask(String audioFilePath, String instrument) {
-
-        // 🆕 Mock 모드일 경우 가짜 응답 반환
         if (mockMode) {
             log.warn("⚠️ AI 서버 Mock 모드 활성화 - 실제 AI 서버에 요청하지 않음");
-            return createMockResponse();
+            return createMockEnqueueResponse();
         }
 
-        // 실제 AI 서버 호출
         return callRealAiServer(audioFilePath, instrument);
     }
 
     /**
-     * 🆕 Mock 응답 생성
+     * 🆕 작업 상태 조회
      */
-    private AiEnqueueResponse createMockResponse() {
-        String mockJobId = "mock-ai-job-" + System.currentTimeMillis();
-        String queuedAt = LocalDateTime.now()
-                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    public AiStatusResponse getTaskStatus(String aiJobId) {
+        if (mockMode) {
+            log.warn("⚠️ AI 서버 Mock 모드 - 가짜 상태 반환");
+            return createMockStatusResponse(aiJobId);
+        }
 
-        log.info("✅ Mock AI Job 생성 - jobId: {}", mockJobId);
+        String url = aiServerBaseUrl + "/tasks/e2e-base/status/" + aiJobId;
 
-        return new AiEnqueueResponse(
-                mockJobId,
-                "queued",
-                queuedAt
-        );
+        try {
+            log.info("AI 서버 상태 조회 - URL: {}, aiJobId: {}", url, aiJobId);
+
+            ResponseEntity<AiStatusResponse> response = restTemplate.getForEntity(
+                    url,
+                    AiStatusResponse.class
+            );
+
+            AiStatusResponse result = response.getBody();
+
+            log.info("AI 서버 상태 조회 성공 - aiJobId: {}, status: {}, progress: {}%",
+                    aiJobId, result.getStatus(), result.getProgressPercent());
+
+            return result;
+
+        } catch (RestClientException e) {
+            log.error("AI 서버 상태 조회 실패 - aiJobId: {}", aiJobId, e);
+            throw new GeneralException(Code.AI_SERVER_ERROR,
+                    "AI 서버 상태 조회 실패: " + e.getMessage());
+        }
     }
+
+    /**
+     * 🆕 작업 결과 조회
+     */
+    public AiResultResponse getTaskResult(String aiJobId) {
+        if (mockMode) {
+            log.warn("⚠️ AI 서버 Mock 모드 - 가짜 결과 반환");
+            return createMockResultResponse(aiJobId);
+        }
+
+        String url = aiServerBaseUrl + "/tasks/e2e-base/result/" + aiJobId;
+
+        try {
+            log.info("AI 서버 결과 조회 - URL: {}, aiJobId: {}", url, aiJobId);
+
+            ResponseEntity<AiResultResponse> response = restTemplate.getForEntity(
+                    url,
+                    AiResultResponse.class
+            );
+
+            AiResultResponse result = response.getBody();
+
+            log.info("AI 서버 결과 조회 성공 - aiJobId: {}", aiJobId);
+
+            return result;
+
+        } catch (RestClientException e) {
+            log.error("AI 서버 결과 조회 실패 - aiJobId: {}", aiJobId, e);
+            throw new GeneralException(Code.AI_SERVER_ERROR,
+                    "AI 서버 결과 조회 실패: " + e.getMessage());
+        }
+    }
+
+    // ========== Private Helper Methods ==========
 
     /**
      * 실제 AI 서버 호출
@@ -73,13 +122,11 @@ public class AiServerClient {
         String url = aiServerBaseUrl + "/tasks/e2e-base/enqueue";
 
         try {
-            // Multipart 요청 생성
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 
-            // 파일 경로를 실제 파일로 변환
             String fullPath = uploadDir + audioFilePath.replace("/uploads/audio/", "/");
             File audioFile = new File(fullPath);
 
@@ -94,8 +141,7 @@ public class AiServerClient {
             HttpEntity<MultiValueMap<String, Object>> requestEntity =
                     new HttpEntity<>(body, headers);
 
-            log.info("AI 서버에 E2E Task 등록 요청 - URL: {}, instrument: {}",
-                    url, instrument);
+            log.info("AI 서버 E2E Task 등록 - URL: {}, instrument: {}", url, instrument);
 
             ResponseEntity<AiEnqueueResponse> response = restTemplate.postForEntity(
                     url,
@@ -104,7 +150,6 @@ public class AiServerClient {
             );
 
             AiEnqueueResponse result = response.getBody();
-
             log.info("AI 서버 E2E Task 등록 성공 - aiJobId: {}", result.getJobId());
 
             return result;
@@ -112,7 +157,85 @@ public class AiServerClient {
         } catch (RestClientException e) {
             log.error("AI 서버 E2E Task 등록 실패", e);
             throw new GeneralException(Code.AI_SERVER_ERROR,
-                    "AI 서버와의 통신에 실패했습니다: " + e.getMessage());
+                    "AI 서버 통신 실패: " + e.getMessage());
         }
+    }
+
+    // ========== Mock Response Generators ==========
+
+    /**
+     * Mock Enqueue 응답 생성
+     */
+    private AiEnqueueResponse createMockEnqueueResponse() {
+        String mockJobId = "mock-ai-job-" + System.currentTimeMillis();
+        String queuedAt = LocalDateTime.now()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+        log.info("✅ Mock AI Job 생성 - jobId: {}", mockJobId);
+
+        return new AiEnqueueResponse(mockJobId, "queued", queuedAt);
+    }
+
+    /**
+     * Mock Status 응답 생성
+     */
+    private AiStatusResponse createMockStatusResponse(String aiJobId) {
+        // Mock: 항상 완료 상태 반환하되, 단계별 정보 포함
+
+        AiStatusResponse.AvailableArtifacts artifacts =
+                new AiStatusResponse.AvailableArtifacts(
+                        true,   // separatedTracksReady
+                        true,   // transcriptionReady
+                        true    // chordProgressionReady
+                );
+
+        return new AiStatusResponse(
+                aiJobId,
+                "completed",  // status
+                100,          // progressPercent
+                "completed",  // currentStage
+                artifacts,    // availableArtifacts
+                LocalDateTime.now().minusMinutes(5).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                LocalDateTime.now().minusMinutes(4).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                null          // error
+        );
+    }
+
+    /**
+     * 🆕 Mock Result 응답 생성
+     */
+    private AiResultResponse createMockResultResponse(String aiJobId) {
+        // Mock 데이터 생성
+        AiResultResponse.SeparatedTracks tracks = new AiResultResponse.SeparatedTracks(
+                "/files/separated/guitar_track.opus",
+                "/files/separated/bass_track.opus",
+                "/files/separated/vocal_track.opus",
+                "/files/separated/drums_track.opus"
+        );
+
+        AiResultResponse.ChordProgression chords = new AiResultResponse.ChordProgression(
+                "/files/chords/progression.json",
+                "/files/chords/progression.txt"
+        );
+
+        AiResultResponse.Metadata metadata = new AiResultResponse.Metadata(
+                120,  // tempo
+                "C",  // key
+                243L, // duration
+                "4/4" // time signature
+        );
+
+        AiResultResponse.Outputs outputs = new AiResultResponse.Outputs(
+                tracks,
+                "/files/midi/transcription.mid",
+                chords,
+                metadata
+        );
+
+        log.info("✅ Mock AI Result 생성 - aiJobId: {}", aiJobId);
+
+        return new AiResultResponse(aiJobId, outputs);
     }
 }

--- a/src/main/java/com/example/cap1/domain/transcription/controller/TranscriptionDownloadController.java
+++ b/src/main/java/com/example/cap1/domain/transcription/controller/TranscriptionDownloadController.java
@@ -1,0 +1,176 @@
+package com.example.cap1.domain.transcription.controller;
+
+import com.example.cap1.global.exception.GeneralException;
+import com.example.cap1.global.response.Code;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/transcription/download")
+@RequiredArgsConstructor
+public class TranscriptionDownloadController {
+
+    @Value("${file.transcription-dir:./uploads/transcription}")
+    private String transcriptionDir;
+
+    /**
+     * 음원 분리 파일 다운로드
+     * GET /api/transcription/download/{aiJobId}/separated/{instrument}
+     */
+    @GetMapping("/{aiJobId}/separated/{instrument}")
+    public ResponseEntity<Resource> downloadSeparatedTrack(
+            @PathVariable String aiJobId,
+            @PathVariable String instrument
+            // TODO: JWT 구현 후 @AuthenticationPrincipal User user 추가
+    ) {
+        log.info("음원 분리 파일 다운로드 요청 - aiJobId: {}, instrument: {}",
+                aiJobId, instrument);
+
+        // 악기 유효성 검증
+        if (!isValidInstrument(instrument)) {
+            throw new GeneralException(Code.INSTRUMENT_NOT_SUPPORTED);
+        }
+
+        try {
+            // 파일 경로 구성
+            Path filePath = Paths.get(transcriptionDir)
+                    .resolve(aiJobId)
+                    .resolve("separated")
+                    .resolve(instrument + ".opus")
+                    .normalize();
+
+            log.debug("파일 경로: {}", filePath);
+
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                log.warn("파일을 찾을 수 없거나 읽을 수 없음: {}", filePath);
+                throw new GeneralException(Code.ENTITY_NOT_FOUND, "파일을 찾을 수 없습니다.");
+            }
+
+            // TODO: 권한 확인 (해당 aiJobId가 현재 사용자의 것인지)
+
+            String filename = instrument + "_track.opus";
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"" + filename + "\"")
+                    .body(resource);
+
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("파일 다운로드 실패", e);
+            throw new GeneralException(Code.INTERNAL_ERROR, "파일 다운로드에 실패했습니다.");
+        }
+    }
+
+    /**
+     * MIDI 파일 다운로드
+     * GET /api/transcription/download/{aiJobId}/midi
+     */
+    @GetMapping("/{aiJobId}/midi")
+    public ResponseEntity<Resource> downloadMidi(
+            @PathVariable String aiJobId
+            // TODO: JWT 구현 후 @AuthenticationPrincipal User user 추가
+    ) {
+        log.info("MIDI 파일 다운로드 요청 - aiJobId: {}", aiJobId);
+
+        try {
+            Path filePath = Paths.get(transcriptionDir)
+                    .resolve(aiJobId)
+                    .resolve("transcription.mid")
+                    .normalize();
+
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                log.warn("MIDI 파일을 찾을 수 없음: {}", filePath);
+                throw new GeneralException(Code.ENTITY_NOT_FOUND, "MIDI 파일을 찾을 수 없습니다.");
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"transcription.mid\"")
+                    .body(resource);
+
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("MIDI 파일 다운로드 실패", e);
+            throw new GeneralException(Code.INTERNAL_ERROR, "MIDI 파일 다운로드에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 코드 진행 파일 다운로드
+     * GET /api/transcription/download/{aiJobId}/chords/{format}
+     */
+    @GetMapping("/{aiJobId}/chords/{format}")
+    public ResponseEntity<Resource> downloadChords(
+            @PathVariable String aiJobId,
+            @PathVariable String format  // "json" or "txt"
+            // TODO: JWT 구현 후 @AuthenticationPrincipal User user 추가
+    ) {
+        log.info("코드 진행 파일 다운로드 요청 - aiJobId: {}, format: {}", aiJobId, format);
+
+        // 포맷 유효성 검증
+        if (!format.equals("json") && !format.equals("txt")) {
+            throw new GeneralException(Code.BAD_REQUEST, "지원하지 않는 파일 형식입니다. (json 또는 txt만 가능)");
+        }
+
+        try {
+            String fileName = "chord_progression." + format;
+            Path filePath = Paths.get(transcriptionDir)
+                    .resolve(aiJobId)
+                    .resolve(fileName)
+                    .normalize();
+
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                log.warn("코드 진행 파일을 찾을 수 없음: {}", filePath);
+                throw new GeneralException(Code.ENTITY_NOT_FOUND, "코드 진행 파일을 찾을 수 없습니다.");
+            }
+
+            MediaType mediaType = "json".equals(format)
+                    ? MediaType.APPLICATION_JSON
+                    : MediaType.TEXT_PLAIN;
+
+            return ResponseEntity.ok()
+                    .contentType(mediaType)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"" + fileName + "\"")
+                    .body(resource);
+
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("코드 진행 파일 다운로드 실패", e);
+            throw new GeneralException(Code.INTERNAL_ERROR, "코드 진행 파일 다운로드에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 악기명 유효성 검증
+     */
+    private boolean isValidInstrument(String instrument) {
+        return instrument.equals("guitar")
+                || instrument.equals("bass")
+                || instrument.equals("vocal")
+                || instrument.equals("drums");
+    }
+}

--- a/src/main/java/com/example/cap1/domain/transcription/dto/ai/AiResultResponse.java
+++ b/src/main/java/com/example/cap1/domain/transcription/dto/ai/AiResultResponse.java
@@ -1,0 +1,77 @@
+package com.example.cap1.domain.transcription.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * AI 서버의 /result/{jobId} 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiResultResponse {
+    private String jobId;
+    private Outputs outputs;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Outputs {
+        // 음원 분리 결과
+        @JsonProperty("separated_tracks")
+        private SeparatedTracks separatedTracks;
+
+        // MIDI 변환 결과
+        @JsonProperty("transcription_url")
+        private String transcriptionUrl;  // .mid 파일 URL
+
+        // 코드 진행 결과
+        @JsonProperty("chord_progression")
+        private ChordProgression chordProgression;
+
+        // 메타데이터
+        private Metadata metadata;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SeparatedTracks {
+        @JsonProperty("guitar_track_url")
+        private String guitarTrackUrl;
+
+        @JsonProperty("bass_track_url")
+        private String bassTrackUrl;
+
+        @JsonProperty("vocal_track_url")
+        private String vocalTrackUrl;
+
+        @JsonProperty("drums_track_url")
+        private String drumsTrackUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChordProgression {
+        @JsonProperty("json_url")
+        private String jsonUrl;  // LLM-Chart JSON 파일 URL
+
+        @JsonProperty("txt_url")
+        private String txtUrl;   // 텍스트 파일 URL
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Metadata {
+        private Integer tempo;
+        private String key;
+        private Long duration;  // seconds
+
+        @JsonProperty("time_signature")
+        private String timeSignature;  // "4/4"
+    }
+}

--- a/src/main/java/com/example/cap1/domain/transcription/dto/ai/AiStatusResponse.java
+++ b/src/main/java/com/example/cap1/domain/transcription/dto/ai/AiStatusResponse.java
@@ -1,0 +1,47 @@
+package com.example.cap1.domain.transcription.dto.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * AI 서버의 /status/{jobId} 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiStatusResponse {
+    private String jobId;
+    private String status;  // "queued", "processing", "completed", "failed"
+    private Integer progressPercent;
+
+    // 🆕 v2 추가 필드
+    private String currentStage;  // "separating", "transcribing", "recognizing_chords"
+    private AvailableArtifacts availableArtifacts;
+
+    private String queuedAt;
+    private String startedAt;
+    private String updatedAt;
+    private String completedAt;
+    private AiError error;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AiError {
+        private String code;
+        private String message;
+    }
+
+    /**
+     * 🆕 각 단계별로 가져올 수 있는 결과물
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailableArtifacts {
+        private Boolean separatedTracksReady;
+        private Boolean transcriptionReady;
+        private Boolean chordProgressionReady;
+    }
+}

--- a/src/main/java/com/example/cap1/domain/transcription/dto/response/TranscriptionStatusResponse.java
+++ b/src/main/java/com/example/cap1/domain/transcription/dto/response/TranscriptionStatusResponse.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)  // null 필드는 응답에서 제외
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TranscriptionStatusResponse {
 
     private String jobId;
@@ -24,8 +24,12 @@ public class TranscriptionStatusResponse {
     private Integer progressPercent;
     private String instrument;
 
+    // 🆕 v2 추가 필드
+    private String currentStage;
+    private AvailableResults availableResults;
+
     // 성공 시
-    private String musicId;  // sheetId
+    private String musicId;
 
     // 실패 시
     private String errorMessage;
@@ -45,13 +49,65 @@ public class TranscriptionStatusResponse {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     private LocalDateTime updatedAt;
 
+    /**
+     * 🆕 다운로드 가능한 중간 산출물 정보
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class AvailableResults {
+        private SeparatedTracks separatedTracks;
+        private String midiUrl;
+        private ChordProgression chordProgression;
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class SeparatedTracks {
+            private String guitarUrl;
+            private String bassUrl;
+            private String vocalUrl;
+            private String drumsUrl;
+        }
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class ChordProgression {
+            private String jsonUrl;
+            private String txtUrl;
+        }
+    }
+
+    /**
+     * 기존 호환성 유지용 팩토리 메서드
+     */
     public static TranscriptionStatusResponse from(TranscriptionJob job) {
+        return from(job, null, null);
+    }
+
+    /**
+     * 🆕 v2 팩토리 메서드 (currentStage, availableResults 포함)
+     */
+    public static TranscriptionStatusResponse from(
+            TranscriptionJob job,
+            String currentStage,
+            AvailableResults availableResults) {
+
         return TranscriptionStatusResponse.builder()
                 .jobId(String.valueOf(job.getId()))
                 .aiJobId(job.getAiJobId())
                 .status(job.getProgressStage())
                 .progressPercent(job.getProgressPercent())
                 .instrument(job.getInstrument())
+                .currentStage(currentStage)
+                .availableResults(availableResults)
                 .musicId(job.getSheetId() != null ? String.valueOf(job.getSheetId()) : null)
                 .errorMessage(job.getErrorMessage())
                 .queuedAt(job.getQueuedAt())

--- a/src/main/java/com/example/cap1/domain/transcription/service/TranscriptionService.java
+++ b/src/main/java/com/example/cap1/domain/transcription/service/TranscriptionService.java
@@ -12,11 +12,19 @@ import com.example.cap1.domain.transcription.dto.response.TranscriptionStatusRes
 import com.example.cap1.domain.transcription.repository.TranscriptionJobRepository;
 import com.example.cap1.global.exception.GeneralException;
 import com.example.cap1.global.response.Code;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.FileSystemUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @Slf4j
@@ -28,6 +36,63 @@ public class TranscriptionService {
     private final TranscriptionJobRepository transcriptionJobRepository;
     private final AudioRepository audioRepository;
     private final AiServerClient aiServerClient;
+
+    @Value("${file.transcription-dir:./uploads/transcription}")
+    private String transcriptionDir;
+
+    @Value("${ai.server.mock-mode:true}")
+    private boolean mockMode;
+
+    /**
+     * 🆕 서버 시작 시 더미 파일 준비
+     */
+    @PostConstruct
+    public void initDummyFiles() {
+        if (!mockMode) {
+            log.info("Mock 모드가 아니므로 더미 파일 초기화 생략");
+            return;
+        }
+
+        try {
+            // transcription 디렉토리 생성
+            Path targetBasePath = Paths.get(transcriptionDir);
+            Files.createDirectories(targetBasePath);
+
+            log.info("✅ 더미 파일 디렉토리 준비 완료 - 경로: {}", targetBasePath);
+            log.info("💡 악보 생성 요청 시 자동으로 해당 aiJobId 디렉토리에 복사됩니다.");
+
+        } catch (IOException e) {
+            log.warn("⚠️ 더미 파일 초기화 실패 (테스트 시에만 필요) - {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 🆕 Mock 모드일 때 더미 파일 복사
+     */
+    private void copyDummyFilesForJob(String aiJobId) {
+        if (!mockMode) {
+            return;
+        }
+
+        try {
+            ClassPathResource dummyResource = new ClassPathResource("dummy/transcription/mock-ai-job-default");
+            Path sourcePath = dummyResource.getFile().toPath();
+            Path targetPath = Paths.get(transcriptionDir).resolve(aiJobId);
+
+            // 이미 존재하면 스킵
+            if (Files.exists(targetPath)) {
+                log.debug("더미 파일이 이미 존재함: {}", targetPath);
+                return;
+            }
+
+            // 디렉토리 복사
+            FileSystemUtils.copyRecursively(sourcePath, targetPath);
+            log.info("✅ Mock 모드: 더미 파일 복사 완료 - {}", targetPath);
+
+        } catch (IOException e) {
+            log.warn("⚠️ 더미 파일 복사 실패 (테스트에는 영향 없음) - {}", e.getMessage());
+        }
+    }
 
     /**
      * 악보 생성 요청 (E2E 파이프라인 시작)
@@ -85,8 +150,12 @@ public class TranscriptionService {
             // 6. AI Job ID 저장 및 상태 변경
             savedJob.updateAiJobId(aiResponse.getJobId());
             savedJob.updateStatus(ProgressStage.PROCESSING);
+            savedJob.updateProgressPercent(0);
 
             transcriptionJobRepository.save(savedJob);
+
+            // 🆕 Mock 모드일 때 더미 파일 복사
+            copyDummyFilesForJob(aiResponse.getJobId());
 
             log.info("AI 서버 E2E Task 등록 완료 - jobId: {}, aiJobId: {}",
                     savedJob.getId(), aiResponse.getJobId());
@@ -106,7 +175,7 @@ public class TranscriptionService {
     }
 
     /**
-     * 🆕 악보 생성 상태 조회
+     * 🆕 악보 생성 상태 조회 (v2 - 단계별 정보 포함)
      */
     public TranscriptionStatusResponse getTranscriptionStatus(Long jobId, Long userId) {
         log.info("악보 생성 상태 조회 - jobId: {}, userId: {}", jobId, userId);
@@ -122,9 +191,88 @@ public class TranscriptionService {
             throw new GeneralException(Code.JOB_FORBIDDEN);
         }
 
-        log.info("작업 상태 조회 완료 - jobId: {}, status: {}, progress: {}%",
-                jobId, job.getProgressStage(), job.getProgressPercent());
+        // 🆕 3. currentStage 결정
+        String currentStage = determineCurrentStage(job);
 
-        return TranscriptionStatusResponse.from(job);
+        // 🆕 4. availableResults 생성
+        TranscriptionStatusResponse.AvailableResults availableResults =
+                buildAvailableResults(job);
+
+        log.info("작업 상태 조회 완료 - jobId: {}, status: {}, stage: {}, progress: {}%",
+                jobId, job.getProgressStage(), currentStage, job.getProgressPercent());
+
+        return TranscriptionStatusResponse.from(job, currentStage, availableResults);
+    }
+
+    /**
+     * 🆕 현재 단계 결정
+     */
+    private String determineCurrentStage(TranscriptionJob job) {
+        if (job.getProgressStage() == ProgressStage.COMPLETED) {
+            return "completed";
+        } else if (job.getProgressStage() == ProgressStage.FAILED) {
+            Integer progress = job.getProgressPercent();
+            if (progress == null || progress < 35) return "separating";
+            if (progress < 65) return "transcribing";
+            if (progress < 95) return "recognizing_chords";
+            return "generating_sheet";
+        } else if (job.getProgressStage() == ProgressStage.PROCESSING) {
+            Integer progress = job.getProgressPercent();
+            if (progress == null || progress < 35) return "separating";
+            if (progress < 65) return "transcribing";
+            if (progress < 95) return "recognizing_chords";
+            return "generating_sheet";
+        }
+        return "pending";
+    }
+
+    /**
+     * 🆕 다운로드 가능한 파일 정보 생성
+     */
+    private TranscriptionStatusResponse.AvailableResults buildAvailableResults(
+            TranscriptionJob job) {
+
+        if (job.getProgressStage() == ProgressStage.PENDING) {
+            return null;
+        }
+
+        String aiJobId = job.getAiJobId();
+        Integer progress = job.getProgressPercent();
+
+        if (progress == null) {
+            progress = 0;
+        }
+
+        TranscriptionStatusResponse.AvailableResults.AvailableResultsBuilder builder =
+                TranscriptionStatusResponse.AvailableResults.builder();
+
+        // Stage 1 완료: 음원 분리 (35% 이상)
+        if (progress >= 35) {
+            builder.separatedTracks(
+                    TranscriptionStatusResponse.AvailableResults.SeparatedTracks.builder()
+                            .guitarUrl("/api/transcription/download/" + aiJobId + "/separated/guitar")
+                            .bassUrl("/api/transcription/download/" + aiJobId + "/separated/bass")
+                            .vocalUrl("/api/transcription/download/" + aiJobId + "/separated/vocal")
+                            .drumsUrl("/api/transcription/download/" + aiJobId + "/separated/drums")
+                            .build()
+            );
+        }
+
+        // Stage 2 완료: MIDI 변환 (65% 이상)
+        if (progress >= 65) {
+            builder.midiUrl("/api/transcription/download/" + aiJobId + "/midi");
+        }
+
+        // Stage 3 완료: 코드 인지 (95% 이상)
+        if (progress >= 95) {
+            builder.chordProgression(
+                    TranscriptionStatusResponse.AvailableResults.ChordProgression.builder()
+                            .jsonUrl("/api/transcription/download/" + aiJobId + "/chords/json")
+                            .txtUrl("/api/transcription/download/" + aiJobId + "/chords/txt")
+                            .build()
+            );
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
## 📌 연관 이슈
- #

## 💻 작업 내용
- [x] 음원 업로드 API 구현 및 테스트
- [x] 악보 생성 요청 API 구현 (E2E Task 등록)
- [x] 악보 생성 상태 조회 API v2 구현
  - [x] 현재 진행 단계 표시 (currentStage)
  - [x] 해당 단계 산출물 나오면 자동할 수 있도록 설정 (availableResults)
- [x] 다운로드 API 구현
  - [x] 음원 분리 파일 다운로드 (guitar, bass, vocal, drums)
  - [x] MIDI 파일 다운로드
  - [x] 코드 진행 파일 다운로드 (JSON, TXT)
- [x] Mock 모드로 전체 플로우 테스트 완료
- [x] MySQL 테이블 구조 snake_case로 통일
- [x] 더미 파일 자동 복사 기능 구현

### 📸 스크린샷 (선택)


### 💬리뷰 요구사항(선택)

